### PR TITLE
Fixed outdated copyrights and org name

### DIFF
--- a/BarcodeHero/BarcodeHero/BarcodeHero.h
+++ b/BarcodeHero/BarcodeHero/BarcodeHero.h
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 10/18/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/BarcodeHero/BarcodeHero/Core/BHBarcodeOptions.swift
+++ b/BarcodeHero/BarcodeHero/Core/BHBarcodeOptions.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 11/6/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import Foundation

--- a/BarcodeHero/BarcodeHero/Core/BHError.swift
+++ b/BarcodeHero/BarcodeHero/Core/BHError.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 11/4/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import AVFoundation

--- a/BarcodeHero/BarcodeHero/Core/Enums.swift
+++ b/BarcodeHero/BarcodeHero/Core/Enums.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 10/19/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import AVFoundation

--- a/BarcodeHero/BarcodeHero/Core/Extensions/CIImage+Transform.swift
+++ b/BarcodeHero/BarcodeHero/Core/Extensions/CIImage+Transform.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 10/19/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import Foundation

--- a/BarcodeHero/BarcodeHero/Core/Extensions/String+Convenience.swift
+++ b/BarcodeHero/BarcodeHero/Core/Extensions/String+Convenience.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 11/5/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import Foundation

--- a/BarcodeHero/BarcodeHero/Core/Extensions/UIImage+Resize.swift
+++ b/BarcodeHero/BarcodeHero/Core/Extensions/UIImage+Resize.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 11/4/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import Foundation

--- a/BarcodeHero/BarcodeHero/Core/FilterParameters/BHAztecFilterParameters.swift
+++ b/BarcodeHero/BarcodeHero/Core/FilterParameters/BHAztecFilterParameters.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 10/10/18.
-//  Copyright © 2018 SpotHero. All rights reserved.
+//  Copyright © 2018 SpotHero, Inc. All rights reserved.
 //
 
 import CoreImage

--- a/BarcodeHero/BarcodeHero/Core/FilterParameters/BHCode128FilterParameters.swift
+++ b/BarcodeHero/BarcodeHero/Core/FilterParameters/BHCode128FilterParameters.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 10/10/18.
-//  Copyright © 2018 SpotHero. All rights reserved.
+//  Copyright © 2018 SpotHero, Inc. All rights reserved.
 //
 
 import CoreImage

--- a/BarcodeHero/BarcodeHero/Core/FilterParameters/BHPDF417FilterParameters.swift
+++ b/BarcodeHero/BarcodeHero/Core/FilterParameters/BHPDF417FilterParameters.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 10/10/18.
-//  Copyright © 2018 SpotHero. All rights reserved.
+//  Copyright © 2018 SpotHero, Inc. All rights reserved.
 //
 
 import CoreImage

--- a/BarcodeHero/BarcodeHero/Core/FilterParameters/BHQRFilterParameters.swift
+++ b/BarcodeHero/BarcodeHero/Core/FilterParameters/BHQRFilterParameters.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 10/10/18.
-//  Copyright © 2018 SpotHero. All rights reserved.
+//  Copyright © 2018 SpotHero, Inc. All rights reserved.
 //
 
 import CoreImage

--- a/BarcodeHero/BarcodeHero/Core/Generators/BHCode39Generator.swift
+++ b/BarcodeHero/BarcodeHero/Core/Generators/BHCode39Generator.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 11/4/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 //  http://www.barcodesymbols.com/code39.htm
 //  http://www.barcodeisland.com/code39.phtml

--- a/BarcodeHero/BarcodeHero/Core/Generators/BHCode93Generator.swift
+++ b/BarcodeHero/BarcodeHero/Core/Generators/BHCode93Generator.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 11/5/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import Foundation

--- a/BarcodeHero/BarcodeHero/Core/Generators/BHEANGenerator.swift
+++ b/BarcodeHero/BarcodeHero/Core/Generators/BHEANGenerator.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 11/5/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 //  http://blog.sina.com.cn/s/blog_4015406e0100bsqk.html
 //  http://www.appsbarcode.com/ISBN.php

--- a/BarcodeHero/BarcodeHero/Core/Generators/BHITFGenerator.swift
+++ b/BarcodeHero/BarcodeHero/Core/Generators/BHITFGenerator.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 11/5/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 //  http://www.barcodeisland.com/int2of5.phtml
 //  http://www.gs1au.org/assets/documents/info/user_manuals/barcode_technical_details/ITF_14_Barcode_Structure.pdf

--- a/BarcodeHero/BarcodeHero/Core/Generators/BHNativeBarcodeGenerator.swift
+++ b/BarcodeHero/BarcodeHero/Core/Generators/BHNativeBarcodeGenerator.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 11/4/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import CoreImage

--- a/BarcodeHero/BarcodeHero/Core/Generators/BHUPCEGenerator.swift
+++ b/BarcodeHero/BarcodeHero/Core/Generators/BHUPCEGenerator.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 11/5/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import Foundation

--- a/BarcodeHero/BarcodeHero/Core/Helpers/BHBarcodeGenerator.swift
+++ b/BarcodeHero/BarcodeHero/Core/Helpers/BHBarcodeGenerator.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 10/19/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import AVFoundation

--- a/BarcodeHero/BarcodeHero/Core/Helpers/BHImageHelper.swift
+++ b/BarcodeHero/BarcodeHero/Core/Helpers/BHImageHelper.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 11/5/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import AVFoundation

--- a/BarcodeHero/BarcodeHero/Core/Protocols/BHBarcodeGenerating.swift
+++ b/BarcodeHero/BarcodeHero/Core/Protocols/BHBarcodeGenerating.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 11/4/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import Foundation

--- a/BarcodeHero/BarcodeHero/Core/Protocols/BHFilterParameterizable.swift
+++ b/BarcodeHero/BarcodeHero/Core/Protocols/BHFilterParameterizable.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 11/7/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import CoreImage

--- a/BarcodeHero/BarcodeHero/UI/Controllers/BHCameraScanController.swift
+++ b/BarcodeHero/BarcodeHero/UI/Controllers/BHCameraScanController.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 6/8/16.
-//  Copyright © 2016 SpotHero. All rights reserved.
+//  Copyright © 2016 SpotHero, Inc. All rights reserved.
 //
 
 import AVFoundation

--- a/BarcodeHero/BarcodeHero/UI/Extensions/UIView+Mask.swift
+++ b/BarcodeHero/BarcodeHero/UI/Extensions/UIView+Mask.swift
@@ -3,7 +3,7 @@
 //  BarcodeHero
 //
 //  Created by Brian Drelling on 11/6/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import AVFoundation

--- a/BarcodeHero/BarcodeHeroDemo/AppDelegate.swift
+++ b/BarcodeHero/BarcodeHeroDemo/AppDelegate.swift
@@ -3,7 +3,7 @@
 //  BarcodeHeroDemo
 //
 //  Created by Brian Drelling on 10/18/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import UIKit

--- a/BarcodeHero/BarcodeHeroDemo/Controllers/BarcodeTypesController.swift
+++ b/BarcodeHero/BarcodeHeroDemo/Controllers/BarcodeTypesController.swift
@@ -3,7 +3,7 @@
 //  BarcodeHeroDemo
 //
 //  Created by Brian Drelling on 11/4/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import BarcodeHero

--- a/BarcodeHero/BarcodeHeroDemo/Controllers/GeneratorController.swift
+++ b/BarcodeHero/BarcodeHeroDemo/Controllers/GeneratorController.swift
@@ -3,7 +3,7 @@
 //  BarcodeHeroDemo
 //
 //  Created by Brian Drelling on 10/19/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import AVFoundation

--- a/BarcodeHero/BarcodeHeroDemo/Controllers/MainNavigationController.swift
+++ b/BarcodeHero/BarcodeHeroDemo/Controllers/MainNavigationController.swift
@@ -3,7 +3,7 @@
 //  BarcodeHeroDemo
 //
 //  Created by Brian Drelling on 11/8/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import Foundation

--- a/BarcodeHero/BarcodeHeroDemo/Controllers/MainViewController.swift
+++ b/BarcodeHero/BarcodeHeroDemo/Controllers/MainViewController.swift
@@ -3,7 +3,7 @@
 //  BarcodeHeroDemo
 //
 //  Created by Brian Drelling on 10/18/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import BarcodeHero

--- a/BarcodeHero/BarcodeHeroDemo/Controllers/MultiGeneratorController.swift
+++ b/BarcodeHero/BarcodeHeroDemo/Controllers/MultiGeneratorController.swift
@@ -3,7 +3,7 @@
 //  BarcodeHeroDemo
 //
 //  Created by Brian Drelling on 11/5/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import AVFoundation

--- a/BarcodeHero/BarcodeHeroDemo/Controllers/ReaderDelegationController.swift
+++ b/BarcodeHero/BarcodeHeroDemo/Controllers/ReaderDelegationController.swift
@@ -3,7 +3,7 @@
 //  BarcodeHeroDemo
 //
 //  Created by Brian Drelling on 11/6/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import AVFoundation

--- a/BarcodeHero/BarcodeHeroDemo/Extensions/UITextField+LoadDropdownData.swift
+++ b/BarcodeHero/BarcodeHeroDemo/Extensions/UITextField+LoadDropdownData.swift
@@ -3,7 +3,7 @@
 //  BarcodeHeroDemo
 //
 //  Created by Brian Drelling on 10/19/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import Foundation

--- a/BarcodeHero/BarcodeHeroDemo/Views/BHPickerView.swift
+++ b/BarcodeHero/BarcodeHeroDemo/Views/BHPickerView.swift
@@ -3,7 +3,7 @@
 //  BarcodeHeroDemo
 //
 //  Created by Brian Drelling on 10/19/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import Foundation

--- a/BarcodeHero/BarcodeHeroDemo/Views/BarcodeCell.swift
+++ b/BarcodeHero/BarcodeHeroDemo/Views/BarcodeCell.swift
@@ -3,7 +3,7 @@
 //  BarcodeHeroDemo
 //
 //  Created by Brian Drelling on 11/4/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import BarcodeHero

--- a/BarcodeHero/BarcodeHeroDemo/Views/BarcodeTypeCell.swift
+++ b/BarcodeHero/BarcodeHeroDemo/Views/BarcodeTypeCell.swift
@@ -3,7 +3,7 @@
 //  BarcodeHeroDemo
 //
 //  Created by Brian Drelling on 11/4/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 import BarcodeHero

--- a/BarcodeHero/BarcodeHeroTests/BarcodeHeroTests.swift
+++ b/BarcodeHero/BarcodeHeroTests/BarcodeHeroTests.swift
@@ -3,7 +3,7 @@
 //  BarcodeHeroTests
 //
 //  Created by Brian Drelling on 11/6/17.
-//  Copyright © 2017 SpotHero. All rights reserved.
+//  Copyright © 2017 SpotHero, Inc. All rights reserved.
 //
 
 @testable import BarcodeHero


### PR DESCRIPTION
**Description**
- Fixed copyright lines in header to say `SpotHero, Inc.` instead of `SpotHero`, `Parking Panda`, or anything else.
- Updated all projects to use the org name `SpotHero, Inc.`.
