### PR TITLE
Updated Podspec for 0.5.0

### DIFF
--- a/BarcodeHero.podspec
+++ b/BarcodeHero.podspec
@@ -3,7 +3,8 @@
 Pod::Spec.new do |spec|
   # Root Specification
   spec.name     = 'BarcodeHero'
-  spec.version  = '0.4.0'
+  spec.version  = '0.5.0'
+  spec.swift_versions = ['5.0', '5.1']
 
   spec.author   = { 'SpotHero' => 'ios@spothero.com' }
   spec.homepage = 'https://github.com/SpotHero/BarcodeHero-iOS'
@@ -14,10 +15,7 @@ Pod::Spec.new do |spec|
 
   # Platform
   spec.ios.deployment_target = '8.0'
-  # CocoaPods can't support our current method of implementing BarcodeHeroUI on macOS
-  # When Mac Catalyst support is out, we can re-enable this if we want to
-  # spec.osx.deployment_target = '10.15'
-  spec.swift_versions = ['5.0', '5.1']
+  spec.osx.deployment_target = '10.15'
 
   # Build Settings
   # spec.frameworks = 'AVFoundation', 'CoreImage', 'UIKit'

--- a/BarcodeHero.podspec
+++ b/BarcodeHero.podspec
@@ -16,9 +16,7 @@ Pod::Spec.new do |spec|
 
   # Platform
   spec.ios.deployment_target = '8.0'
-  # CocoaPods can't support our current method of implementing BarcodeHeroUI on macOS
-  # When Mac Catalyst support is out, we can re-enable this if we want to
-  # spec.osx.deployment_target = '10.15'
+  spec.osx.deployment_target = '10.15'
 
   # Build Settings
   # spec.frameworks = 'AVFoundation', 'CoreImage', 'UIKit'

--- a/BarcodeHero.podspec
+++ b/BarcodeHero.podspec
@@ -4,14 +4,14 @@ Pod::Spec.new do |spec|
   # Root Specification
   spec.name     = 'BarcodeHero'
   spec.version  = '0.5.0'
-  
+
   spec.swift_versions = ['5.0', '5.1']
 
   spec.author   = { 'SpotHero' => 'ios@spothero.com' }
   spec.homepage = 'https://github.com/SpotHero/BarcodeHero-iOS'
   spec.license  = { type: 'MIT', file: 'LICENSE' }
-  spec.source   = { :git => 'https://github.com/SpotHero/BarcodeHero-iOS.git',
-                    :tag => spec.version.to_s }
+  spec.source   = { git: 'https://github.com/SpotHero/BarcodeHero-iOS.git',
+                    tag: spec.version.to_s }
   spec.summary  = 'Allows easy generation of barcodes.'
 
   # Platform

--- a/BarcodeHero.podspec
+++ b/BarcodeHero.podspec
@@ -4,6 +4,7 @@ Pod::Spec.new do |spec|
   # Root Specification
   spec.name     = 'BarcodeHero'
   spec.version  = '0.5.0'
+  
   spec.swift_versions = ['5.0', '5.1']
 
   spec.author   = { 'SpotHero' => 'ios@spothero.com' }
@@ -15,7 +16,9 @@ Pod::Spec.new do |spec|
 
   # Platform
   spec.ios.deployment_target = '8.0'
-  spec.osx.deployment_target = '10.15'
+  # CocoaPods can't support our current method of implementing BarcodeHeroUI on macOS
+  # When Mac Catalyst support is out, we can re-enable this if we want to
+  # spec.osx.deployment_target = '10.15'
 
   # Build Settings
   # spec.frameworks = 'AVFoundation', 'CoreImage', 'UIKit'


### PR DESCRIPTION
**Description**
- Bumped version to `0.5.0`.
- Added `osx` support, now that it works with the `UIKit` imports and no resource files.
- Moved `swift_versions` into the `Root Specification` section inline with the Podspec Syntax Guide.
