### PR TITLE
feature/remove image scaling during resizing

### DIFF
--- a/Sources/BarcodeHeroCore/Helpers/BHImageHelper.swift
+++ b/Sources/BarcodeHeroCore/Helpers/BHImageHelper.swift
@@ -175,7 +175,7 @@ private extension CGContext {
 
         // If we can import UIKit, attempt to create the CGContext from the current UIGraphics context
         #if canImport(UIKit)
-            UIGraphicsBeginImageContextWithOptions(size, false, 0)
+            UIGraphicsBeginImageContextWithOptions(size, false, 1)
 
             context = UIGraphicsGetCurrentContext()
         #endif


### PR DESCRIPTION
**Description**
Noticed that I was getting double-sized barcodes back when I passed in a set width. Seems that `UIGraphicsBeginImageContextWithOptions` behavior when passing in 0 is to scale whatever is in the context by the current device's resolution (1x, 2x, or 3x). 

Since we're passing in a desired width, it seemed weird to then get back something double or triple in size compared to what was passed in. In the future if we desire this functionality I could see adding customizable input arguments for auto-scaling.
