### PR TITLE
IOS-1389: Ensuring that 2D barcodes keep the right orientation when scaled

### DIFF
--- a/Sources/BarcodeHeroCore/Helpers/BHImageHelper.swift
+++ b/Sources/BarcodeHeroCore/Helpers/BHImageHelper.swift
@@ -144,8 +144,12 @@ class BHImageHelper {
                 throw BHError.couldNotGetGraphicsContext
             }
 
-//        context.setShouldAntialias(false)
             context.interpolationQuality = CGInterpolationQuality.none
+            
+            // this puts the origin of the coordinate system into the top-left for drawing,
+            // which makes 2D codes orient properly when drawn
+            context.translateBy(x: 0, y: height)
+            context.scaleBy(x: 1, y: -1)
 
             context.draw(image, in: CGRect(x: x, y: y, width: width, height: height))
 


### PR DESCRIPTION
**JIRA URL**
https://spothero.atlassian.net/browse/IOS-1389

**Description**
Just a quick fix while I was in BarcodeHero to ensure QR, Aztec, and other 2D codes are not flipped when scaled using the UIKit scaling methods.