### PR TITLE
IOS-1479: Removed all padding from non-native barcode generation

### DIFF
--- a/BarcodeHero.podspec
+++ b/BarcodeHero.podspec
@@ -3,7 +3,7 @@
 Pod::Spec.new do |spec|
   # Root Specification
   spec.name     = 'BarcodeHero'
-  spec.version  = '0.5.1'
+  spec.version  = '0.6.0'
 
   spec.swift_versions = ['5.0', '5.1']
 

--- a/BarcodeHeroDemo/BarcodeHeroDemo/Controllers/GeneratorController.swift
+++ b/BarcodeHeroDemo/BarcodeHeroDemo/Controllers/GeneratorController.swift
@@ -9,7 +9,8 @@ import UIKit
 class GeneratorController: UIViewController {
     // MARK: - Constants
     
-    private static let debugColorsEnabled = true
+    // TODO: Make this configurable on the controller display
+    private static let debugColorsEnabled = false
     
     // MARK: - Properties
 

--- a/BarcodeHeroDemo/BarcodeHeroDemo/Controllers/GeneratorController.swift
+++ b/BarcodeHeroDemo/BarcodeHeroDemo/Controllers/GeneratorController.swift
@@ -7,6 +7,10 @@ import Foundation
 import UIKit
 
 class GeneratorController: UIViewController {
+    // MARK: - Constants
+    
+    private static let debugColorsEnabled = true
+    
     // MARK: - Properties
 
     @IBOutlet private var alertLabel: UILabel!
@@ -88,8 +92,17 @@ class GeneratorController: UIViewController {
     func regenerateBarcode() {
         do {
             self.alertView?.isHidden = true
+            
+            var options: BHBarcodeOptions?
+            
+            // If debug colors are enabled, this will draw codes with a blue stroke on a red background
+            if #available(iOS 13.0, *), Self.debugColorsEnabled {
+                options = BHBarcodeOptions(fillColor: CGColor(srgbRed: 1, green: 0, blue: 0, alpha: 1),
+                                           strokeColor: CGColor(srgbRed: 0, green: 0, blue: 1, alpha: 1),
+                                           filterParameters: nil)
+            }
 
-            let cgImage = try BHBarcodeGenerator.generate(self.type, withData: self.data)
+            let cgImage = try BHBarcodeGenerator.generate(self.type, withData: self.data, options: options)
             let image = try UIImage(cgImage: cgImage).bh_resizedTo(self.barcodeImageView)
 
             self.barcodeImageView?.image = image

--- a/Sources/BarcodeHeroCore/Helpers/BHImageHelper.swift
+++ b/Sources/BarcodeHeroCore/Helpers/BHImageHelper.swift
@@ -9,6 +9,25 @@ import Foundation
 #endif
 
 class BHImageHelper {
+    /// The default top spacing of the CIImage generated AVMetadataObjectTypePDF417Code type image
+    private static let topSpacing: CGFloat = 0
+    
+    /// The default top spacing of the CIImage generated AVMetadataObjectTypePDF417Code type image
+    private static let bottomSpacing: CGFloat = 0
+    
+    /// The default left and right spacing of the CIImage generated AVMetadataObjectTypePDF417Code type image
+    private static let sideSpacing: CGFloat = 0
+    
+    /// The default height of the CIImage generated AVMetadataObjectTypePDF417Code type image
+    private static let height: CGFloat = 28
+    
+    /// The default line width for a 1D barcode
+    private static let lineWidth: CGFloat = 1
+    
+    /// The spacing to provide to the quiet zone all around
+    /// For 1D barcodes, this should be 10 times the width of the narrowest bar or 1/8 inch, whichever is greater
+    private static let quietZoneSpacing: CGFloat = Self.lineWidth * 10
+    
     static func draw(_ data: String, options: BHBarcodeOptions? = nil) throws -> CGImage? {
         guard !data.isEmpty else {
             throw BHError.dataRequired
@@ -16,12 +35,7 @@ class BHImageHelper {
 
         let options = options ?? BHBarcodeOptions()
 
-        // Values taken from CIImage generated AVMetadataObjectTypePDF417Code type image
-        // Top spacing          = 1.5
-        // Bottom spacing       = 2
-        // Left & right spacing = 2
-        // Height               = 28
-        let size = CGSize(width: data.count + 4, height: 28)
+        let size = CGSize(width: CGFloat(data.count) + (Self.sideSpacing * 2), height: Self.height)
 
         guard let context = CGContext.from(size: size) else {
             throw BHError.couldNotGetGraphicsContext
@@ -38,16 +52,17 @@ class BHImageHelper {
         }
 
         context.fill(CGRect(origin: .zero, size: size))
-        context.setLineWidth(1)
+        context.setLineWidth(Self.lineWidth)
 
         for index in 0 ..< data.count {
+            // 1 implies that nothing is drawn ("quiet zone")
             guard data[index] == "1" else {
                 continue
             }
 
-            let x = index + (2 + 1)
-            context.move(to: CGPoint(x: CGFloat(x), y: 1.5))
-            context.addLine(to: CGPoint(x: CGFloat(x), y: size.height - 2))
+            let x = CGFloat(index) + (Self.sideSpacing + 1)
+            context.move(to: CGPoint(x: x, y: Self.topSpacing))
+            context.addLine(to: CGPoint(x: x, y: size.height - Self.bottomSpacing))
         }
 
         context.drawPath(using: CGPathDrawingMode.fillStroke)
@@ -144,8 +159,12 @@ class BHImageHelper {
                 throw BHError.couldNotGetGraphicsContext
             }
 
-//        context.setShouldAntialias(false)
             context.interpolationQuality = CGInterpolationQuality.none
+            
+            // this puts the origin of the coordinate system into the top-left for drawing,
+            // which makes 2D codes orient properly when drawn
+            context.translateBy(x: 0, y: height)
+            context.scaleBy(x: 1, y: -1)
 
             context.draw(image, in: CGRect(x: x, y: y, width: width, height: height))
 

--- a/Sources/BarcodeHeroCore/Helpers/BHImageHelper.swift
+++ b/Sources/BarcodeHeroCore/Helpers/BHImageHelper.swift
@@ -15,18 +15,16 @@ class BHImageHelper {
     /// The default top spacing of the CIImage generated AVMetadataObjectTypePDF417Code type image
     private static let bottomSpacing: CGFloat = 0
     
-    /// The default left and right spacing of the CIImage generated AVMetadataObjectTypePDF417Code type image
-    private static let sideSpacing: CGFloat = 0
-    
     /// The default height of the CIImage generated AVMetadataObjectTypePDF417Code type image
     private static let height: CGFloat = 28
     
     /// The default line width for a 1D barcode
     private static let lineWidth: CGFloat = 1
     
+    // TODO: For now, we're not use Quiet Zone spacing and we're expecting the client to adjust padding on their own
     /// The spacing to provide to the quiet zone all around
     /// For 1D barcodes, this should be 10 times the width of the narrowest bar or 1/8 inch, whichever is greater
-    private static let quietZoneSpacing: CGFloat = Self.lineWidth * 10
+    private static let quietZoneSpacing: CGFloat = 0 // Self.lineWidth * 10
     
     static func draw(_ data: String, options: BHBarcodeOptions? = nil) throws -> CGImage? {
         guard !data.isEmpty else {
@@ -35,7 +33,7 @@ class BHImageHelper {
 
         let options = options ?? BHBarcodeOptions()
 
-        let size = CGSize(width: CGFloat(data.count) + (Self.sideSpacing * 2), height: Self.height)
+        let size = CGSize(width: CGFloat(data.count) + (Self.quietZoneSpacing * 2), height: Self.height)
 
         guard let context = CGContext.from(size: size) else {
             throw BHError.couldNotGetGraphicsContext
@@ -60,7 +58,7 @@ class BHImageHelper {
                 continue
             }
 
-            let x = CGFloat(index) + (Self.sideSpacing + 1)
+            let x = CGFloat(index) + (Self.quietZoneSpacing + 1)
             context.move(to: CGPoint(x: x, y: Self.topSpacing))
             context.addLine(to: CGPoint(x: x, y: size.height - Self.bottomSpacing))
         }


### PR DESCRIPTION
**JIRA URL**
https://spothero.atlassian.net/browse/IOS-1479

**Description**
- Broke the numbers in `BHImageHelper` into named, static properties.
- Set all padding to `0` for non-native, 1D barcodes.
- For `BarcodeHeroDemo`, I added `debugColorsEnabled` flag to toggle debug colors for easier testing.
