### PR TITLE
IOS-1879: Added proper handling for watchOS and tvOS targets

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -62,7 +62,8 @@ cyclomatic_complexity: # Complexity of function bodies should be limited.
   ignores_case_statements: true # ignores switch statements
 empty_count: warning # Prefer checking `isEmpty` over comparing `count` to zero.
 file_header:
-  required_pattern: "// Copyright © 2019 SpotHero, Inc. All rights reserved."
+  required_pattern: |
+    \/\/  Copyright © \d{4} SpotHero, Inc\. All rights reserved\.
 file_name: # File name should match a type or extension declared in the file (if any).
   excluded: ["Enums.swift"]
 file_length: # Files should not span too many lines.
@@ -105,9 +106,9 @@ type_body_length: # Type bodies should not span too many lines.
 
 excluded: # what folders should be excluded from analysis?
   # CocoaPods
-  - Pods 
+  - Pods
   # Swift Package Manager
-  - .build 
+  - .build
   - .swiftpm
   - Tests/LinuxMain.swift
   - "Tests/*/XCTestManifests.swift"

--- a/BarcodeHero.podspec
+++ b/BarcodeHero.podspec
@@ -3,7 +3,7 @@
 Pod::Spec.new do |spec|
   # Root Specification
   spec.name     = 'BarcodeHero'
-  spec.version  = '0.6.0'
+  spec.version  = '0.7.0'
 
   spec.swift_versions = ['5.0', '5.1']
 

--- a/BarcodeHero.xcworkspace/xcshareddata/xcschemes/BarcodeHeroCore.xcscheme
+++ b/BarcodeHero.xcworkspace/xcshareddata/xcschemes/BarcodeHeroCore.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BarcodeHeroCore"
+               BuildableName = "BarcodeHeroCore"
+               BlueprintName = "BarcodeHeroCore"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BarcodeHeroCore"
+            BuildableName = "BarcodeHeroCore"
+            BlueprintName = "BarcodeHeroCore"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BarcodeHeroDemo/BarcodeHeroDemo/AppDelegate.swift
+++ b/BarcodeHeroDemo/BarcodeHeroDemo/AppDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import UIKit
 

--- a/BarcodeHeroDemo/BarcodeHeroDemo/Controllers/BarcodeTypesController.swift
+++ b/BarcodeHeroDemo/BarcodeHeroDemo/Controllers/BarcodeTypesController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import BarcodeHeroCore
 import BarcodeHeroUI

--- a/BarcodeHeroDemo/BarcodeHeroDemo/Controllers/GeneratorController.swift
+++ b/BarcodeHeroDemo/BarcodeHeroDemo/Controllers/GeneratorController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import AVFoundation
 import BarcodeHeroCore
@@ -8,10 +8,10 @@ import UIKit
 
 class GeneratorController: UIViewController {
     // MARK: - Constants
-    
+
     // TODO: Make this configurable on the controller display
     private static let debugColorsEnabled = false
-    
+
     // MARK: - Properties
 
     @IBOutlet private var alertLabel: UILabel!
@@ -93,9 +93,9 @@ class GeneratorController: UIViewController {
     func regenerateBarcode() {
         do {
             self.alertView?.isHidden = true
-            
+
             var options: BHBarcodeOptions?
-            
+
             // If debug colors are enabled, this will draw codes with a blue stroke on a red background
             if #available(iOS 13.0, *), Self.debugColorsEnabled {
                 options = BHBarcodeOptions(fillColor: CGColor(srgbRed: 1, green: 0, blue: 0, alpha: 1),

--- a/BarcodeHeroDemo/BarcodeHeroDemo/Controllers/MainNavigationController.swift
+++ b/BarcodeHeroDemo/BarcodeHeroDemo/Controllers/MainNavigationController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import Foundation
 import UIKit

--- a/BarcodeHeroDemo/BarcodeHeroDemo/Controllers/MainViewController.swift
+++ b/BarcodeHeroDemo/BarcodeHeroDemo/Controllers/MainViewController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import BarcodeHeroUI
 import UIKit

--- a/BarcodeHeroDemo/BarcodeHeroDemo/Controllers/MultiGeneratorController.swift
+++ b/BarcodeHeroDemo/BarcodeHeroDemo/Controllers/MultiGeneratorController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import AVFoundation
 import BarcodeHeroCore

--- a/BarcodeHeroDemo/BarcodeHeroDemo/Controllers/ReaderDelegationController.swift
+++ b/BarcodeHeroDemo/BarcodeHeroDemo/Controllers/ReaderDelegationController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import AVFoundation
 import BarcodeHeroUI

--- a/BarcodeHeroDemo/BarcodeHeroDemo/Extensions/UITextField+LoadDropdownData.swift
+++ b/BarcodeHeroDemo/BarcodeHeroDemo/Extensions/UITextField+LoadDropdownData.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import Foundation
 import UIKit

--- a/BarcodeHeroDemo/BarcodeHeroDemo/Views/BHPickerView.swift
+++ b/BarcodeHeroDemo/BarcodeHeroDemo/Views/BHPickerView.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import Foundation
 import UIKit

--- a/BarcodeHeroDemo/BarcodeHeroDemo/Views/BarcodeCell.swift
+++ b/BarcodeHeroDemo/BarcodeHeroDemo/Views/BarcodeCell.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import BarcodeHeroCore
 import BarcodeHeroUI

--- a/BarcodeHeroDemo/BarcodeHeroDemo/Views/BarcodeTypeCell.swift
+++ b/BarcodeHeroDemo/BarcodeHeroDemo/Views/BarcodeTypeCell.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import BarcodeHeroCore
 import BarcodeHeroUI

--- a/Sources/BarcodeHeroCore/BHBarcodeOptions.swift
+++ b/Sources/BarcodeHeroCore/BHBarcodeOptions.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import CoreGraphics
 import Foundation

--- a/Sources/BarcodeHeroCore/BHError.swift
+++ b/Sources/BarcodeHeroCore/BHError.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import AVFoundation
 import Foundation
@@ -21,7 +21,6 @@ public enum BHError: Error {
     case nonNativeType(BHBarcodeType)
     case typeRequired
 //    case unknown
-    
 }
 
 extension BHError: LocalizedError {

--- a/Sources/BarcodeHeroCore/BHError.swift
+++ b/Sources/BarcodeHeroCore/BHError.swift
@@ -15,12 +15,13 @@ public enum BHError: Error {
     case dataRequired
     case indexOutOfBounds
     case invalidData(String, for: BHBarcodeType)
-    case invalidMetadataObjectType(AVMetadataObject.ObjectType)
+    case invalidMetadataObjectType(String)
     case invalidType(BHBarcodeType)
     case metadataObjectTypeRequired
     case nonNativeType(BHBarcodeType)
     case typeRequired
 //    case unknown
+    
 }
 
 extension BHError: LocalizedError {
@@ -49,7 +50,7 @@ extension BHError: LocalizedError {
         case let .invalidData(data, barcodeType):
             return "Data '\(data)' is invalid for barcode type '\(barcodeType.rawValue)'."
         case let .invalidMetadataObjectType(metadataObjectType):
-            return "Metadata object type '\(metadataObjectType.rawValue)' is invalid."
+            return "Metadata object type '\(metadataObjectType)' is invalid."
         case let .invalidType(barcodeType):
             return "Barcode type '\(barcodeType.rawValue)' is invalid."
         case .metadataObjectTypeRequired:

--- a/Sources/BarcodeHeroCore/Enums.swift
+++ b/Sources/BarcodeHeroCore/Enums.swift
@@ -24,7 +24,9 @@ public enum BHBarcodeType: String, CaseIterable {
     public var isNative: Bool {
         return [.aztec, .code128, .pdf417, .qr].contains(self)
     }
-
+    
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
     public var metadataObjectType: AVMetadataObject.ObjectType? {
         switch self {
         case .aztec:
@@ -61,7 +63,9 @@ public enum BHBarcodeType: String, CaseIterable {
             return .upce
         }
     }
-
+    
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
     init?(metadataObjectType: AVMetadataObject.ObjectType) {
         switch metadataObjectType {
         case .aztec:

--- a/Sources/BarcodeHeroCore/Enums.swift
+++ b/Sources/BarcodeHeroCore/Enums.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import AVFoundation
 import Foundation
@@ -24,7 +24,7 @@ public enum BHBarcodeType: String, CaseIterable {
     public var isNative: Bool {
         return [.aztec, .code128, .pdf417, .qr].contains(self)
     }
-    
+
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     public var metadataObjectType: AVMetadataObject.ObjectType? {
@@ -63,7 +63,7 @@ public enum BHBarcodeType: String, CaseIterable {
             return .upce
         }
     }
-    
+
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     init?(metadataObjectType: AVMetadataObject.ObjectType) {

--- a/Sources/BarcodeHeroCore/Extensions/CGColor+NamedColors.swift
+++ b/Sources/BarcodeHeroCore/Extensions/CGColor+NamedColors.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import CoreGraphics
 

--- a/Sources/BarcodeHeroCore/Extensions/CGImage+UIImage.swift
+++ b/Sources/BarcodeHeroCore/Extensions/CGImage+UIImage.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 #if canImport(UIKit)
 

--- a/Sources/BarcodeHeroCore/Extensions/CIImage+Transform.swift
+++ b/Sources/BarcodeHeroCore/Extensions/CIImage+Transform.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 #if canImport(CoreImage)
     import CoreGraphics

--- a/Sources/BarcodeHeroCore/Extensions/CIImage+Transform.swift
+++ b/Sources/BarcodeHeroCore/Extensions/CIImage+Transform.swift
@@ -1,28 +1,30 @@
 // Copyright © 2019 SpotHero, Inc. All rights reserved.
 
-import CoreGraphics
-import CoreImage
-import Foundation
+#if canImport(CoreImage)
+    import CoreGraphics
+    import CoreImage
+    import Foundation
 
-#if canImport(UIKit)
-    import UIKit
-#endif
-
-extension CIImage {
     #if canImport(UIKit)
-        func transformedToFit(_ imageView: UIImageView?) -> CIImage? {
-            return self.transformedToFit(imageView?.frame.size)
-        }
+        import UIKit
     #endif
 
-    func transformedToFit(_ size: CGSize?) -> CIImage? {
-        guard let size = size else {
-            return nil
+    extension CIImage {
+        #if canImport(UIKit)
+            func transformedToFit(_ imageView: UIImageView?) -> CIImage? {
+                return self.transformedToFit(imageView?.frame.size)
+            }
+        #endif
+
+        func transformedToFit(_ size: CGSize?) -> CIImage? {
+            guard let size = size else {
+                return nil
+            }
+
+            let scaleX = size.width / extent.size.width
+            let scaleY = size.height / extent.size.height
+
+            return transformed(by: CGAffineTransform(scaleX: scaleX, y: scaleY))
         }
-
-        let scaleX = size.width / extent.size.width
-        let scaleY = size.height / extent.size.height
-
-        return transformed(by: CGAffineTransform(scaleX: scaleX, y: scaleY))
     }
-}
+#endif

--- a/Sources/BarcodeHeroCore/Extensions/CIImage+UIImage.swift
+++ b/Sources/BarcodeHeroCore/Extensions/CIImage+UIImage.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 #if canImport(UIKit) && (os(iOS) || targetEnvironment(macCatalyst))
 

--- a/Sources/BarcodeHeroCore/Extensions/CIImage+UIImage.swift
+++ b/Sources/BarcodeHeroCore/Extensions/CIImage+UIImage.swift
@@ -1,6 +1,6 @@
 // Copyright © 2019 SpotHero, Inc. All rights reserved.
 
-#if canImport(UIKit)
+#if canImport(UIKit) && (os(iOS) || targetEnvironment(macCatalyst))
 
     import Foundation
     import UIKit

--- a/Sources/BarcodeHeroCore/Extensions/String+Convenience.swift
+++ b/Sources/BarcodeHeroCore/Extensions/String+Convenience.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/Sources/BarcodeHeroCore/Extensions/UIImage+Resize.swift
+++ b/Sources/BarcodeHeroCore/Extensions/UIImage+Resize.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 #if canImport(UIKit) && !os(watchOS)
 
@@ -11,13 +11,13 @@
         public func bh_resizedTo(_ imageView: UIImageView) throws -> UIImage? {
             return try self.bh_resizedTo(imageView.bounds.size, forContentMode: imageView.contentMode)
         }
-        
+
         public func bh_resizedTo(_ size: CGSize, forContentMode contentMode: UIView.ContentMode? = nil) throws -> UIImage? {
             if let ciImage = self.ciImage {
                 #if os(tvOS) || os(watchOS)
-                return nil
+                    return nil
                 #else
-                return ciImage.transformedToFit(size)?.uiImage
+                    return ciImage.transformedToFit(size)?.uiImage
                 #endif
             } else if let cgImage = self.cgImage {
                 let contentMode = contentMode ?? .scaleAspectFit

--- a/Sources/BarcodeHeroCore/Extensions/UIImage+Resize.swift
+++ b/Sources/BarcodeHeroCore/Extensions/UIImage+Resize.swift
@@ -1,6 +1,6 @@
 // Copyright © 2019 SpotHero, Inc. All rights reserved.
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 
     import Foundation
     import UIKit
@@ -11,10 +11,14 @@
         public func bh_resizedTo(_ imageView: UIImageView) throws -> UIImage? {
             return try self.bh_resizedTo(imageView.bounds.size, forContentMode: imageView.contentMode)
         }
-
+        
         public func bh_resizedTo(_ size: CGSize, forContentMode contentMode: UIView.ContentMode? = nil) throws -> UIImage? {
             if let ciImage = self.ciImage {
+                #if os(tvOS) || os(watchOS)
+                return nil
+                #else
                 return ciImage.transformedToFit(size)?.uiImage
+                #endif
             } else if let cgImage = self.cgImage {
                 let contentMode = contentMode ?? .scaleAspectFit
                 return try BHImageHelper.resize(cgImage, toSize: size, forContentMode: contentMode).uiImage

--- a/Sources/BarcodeHeroCore/FilterParameters/BHAztecFilterParameters.swift
+++ b/Sources/BarcodeHeroCore/FilterParameters/BHAztecFilterParameters.swift
@@ -1,6 +1,7 @@
 // Copyright © 2019 SpotHero, Inc. All rights reserved.
 
-import CoreImage
+#if canImport(CoreImage)
+    import CoreImage
 import Foundation
 
 // https://developer.apple.com/library/content/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html#//apple_ref/doc/filter/ci/CIAztecCodeGenerator
@@ -17,3 +18,5 @@ public struct BHAztecFilterParameters: BHFilterParameterizable {
         ])
     }
 }
+
+#endif

--- a/Sources/BarcodeHeroCore/FilterParameters/BHAztecFilterParameters.swift
+++ b/Sources/BarcodeHeroCore/FilterParameters/BHAztecFilterParameters.swift
@@ -1,22 +1,22 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 #if canImport(CoreImage)
     import CoreImage
-import Foundation
+    import Foundation
 
-// https://developer.apple.com/library/content/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html#//apple_ref/doc/filter/ci/CIAztecCodeGenerator
-public struct BHAztecFilterParameters: BHFilterParameterizable {
-    public var inputCompactStyle: NSNumber
-    public var inputCorrectionLevel: NSNumber = 23
-    public var inputLayers: NSNumber
+    // https://developer.apple.com/library/content/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html#//apple_ref/doc/filter/ci/CIAztecCodeGenerator
+    public struct BHAztecFilterParameters: BHFilterParameterizable {
+        public var inputCompactStyle: NSNumber
+        public var inputCorrectionLevel: NSNumber = 23
+        public var inputLayers: NSNumber
 
-    public func loadInto(_ filter: CIFilter) {
-        filter.setValuesForKeys([
-            BHAztecFilterParameterKey.inputCompactStyle.rawValue: inputCompactStyle,
-            BHAztecFilterParameterKey.inputCorrectionLevel.rawValue: inputCorrectionLevel,
-            BHAztecFilterParameterKey.inputLayers.rawValue: inputLayers,
-        ])
+        public func loadInto(_ filter: CIFilter) {
+            filter.setValuesForKeys([
+                BHAztecFilterParameterKey.inputCompactStyle.rawValue: inputCompactStyle,
+                BHAztecFilterParameterKey.inputCorrectionLevel.rawValue: inputCorrectionLevel,
+                BHAztecFilterParameterKey.inputLayers.rawValue: inputLayers,
+            ])
+        }
     }
-}
 
 #endif

--- a/Sources/BarcodeHeroCore/FilterParameters/BHCode128FilterParameters.swift
+++ b/Sources/BarcodeHeroCore/FilterParameters/BHCode128FilterParameters.swift
@@ -1,16 +1,16 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 #if canImport(CoreImage)
     import CoreImage
     import Foundation
 
-/// https://developer.apple.com/library/content/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html#//apple_ref/doc/filter/ci/CICode128BarcodeGenerator
-public struct BHCode128FilterParameters: BHFilterParameterizable {
-    public var inputQuietSpace: NSNumber = 0 // default is 7 in the native filter generation
+    /// https://developer.apple.com/library/content/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html#//apple_ref/doc/filter/ci/CICode128BarcodeGenerator
+    public struct BHCode128FilterParameters: BHFilterParameterizable {
+        public var inputQuietSpace: NSNumber = 0 // default is 7 in the native filter generation
 
-    public func loadInto(_ filter: CIFilter) {
-        filter.setValue(self.inputQuietSpace, forKey: BHCode128FilterParameterKey.inputQuietSpace.rawValue)
+        public func loadInto(_ filter: CIFilter) {
+            filter.setValue(self.inputQuietSpace, forKey: BHCode128FilterParameterKey.inputQuietSpace.rawValue)
+        }
     }
-}
 
 #endif

--- a/Sources/BarcodeHeroCore/FilterParameters/BHCode128FilterParameters.swift
+++ b/Sources/BarcodeHeroCore/FilterParameters/BHCode128FilterParameters.swift
@@ -1,7 +1,8 @@
 // Copyright © 2019 SpotHero, Inc. All rights reserved.
 
-import CoreImage
-import Foundation
+#if canImport(CoreImage)
+    import CoreImage
+    import Foundation
 
 /// https://developer.apple.com/library/content/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html#//apple_ref/doc/filter/ci/CICode128BarcodeGenerator
 public struct BHCode128FilterParameters: BHFilterParameterizable {
@@ -11,3 +12,5 @@ public struct BHCode128FilterParameters: BHFilterParameterizable {
         filter.setValue(self.inputQuietSpace, forKey: BHCode128FilterParameterKey.inputQuietSpace.rawValue)
     }
 }
+
+#endif

--- a/Sources/BarcodeHeroCore/FilterParameters/BHPDF417FilterParameters.swift
+++ b/Sources/BarcodeHeroCore/FilterParameters/BHPDF417FilterParameters.swift
@@ -1,38 +1,38 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 #if canImport(CoreImage)
     import CoreImage
     import Foundation
 
-/// https://developer.apple.com/library/content/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html#//apple_ref/doc/filter/ci/CIPDF417BarcodeGenerator
-public struct BHPDF417FilterParameters: BHFilterParameterizable {
-    public var inputAlwaysSpecifyCompaction: NSNumber
-    public var inputCompactionMode: NSNumber
-    public var inputCompactStyle: NSNumber
-    public var inputCorrectionLevel: NSNumber
-    public var inputDataColumns: NSNumber
-    public var inputDataRows: NSNumber
-    public var inputMaxHeight: NSNumber
-    public var inputMaxWidth: NSNumber
-    public var inputMinHeight: NSNumber
-    public var inputMinWidth: NSNumber
-    public var inputPreferredAspectRatio: NSNumber
+    /// https://developer.apple.com/library/content/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html#//apple_ref/doc/filter/ci/CIPDF417BarcodeGenerator
+    public struct BHPDF417FilterParameters: BHFilterParameterizable {
+        public var inputAlwaysSpecifyCompaction: NSNumber
+        public var inputCompactionMode: NSNumber
+        public var inputCompactStyle: NSNumber
+        public var inputCorrectionLevel: NSNumber
+        public var inputDataColumns: NSNumber
+        public var inputDataRows: NSNumber
+        public var inputMaxHeight: NSNumber
+        public var inputMaxWidth: NSNumber
+        public var inputMinHeight: NSNumber
+        public var inputMinWidth: NSNumber
+        public var inputPreferredAspectRatio: NSNumber
 
-    public func loadInto(_ filter: CIFilter) {
-        filter.setValuesForKeys([
-            BHPDF417FilterParameterKey.inputAlwaysSpecifyCompaction.rawValue: inputAlwaysSpecifyCompaction,
-            BHPDF417FilterParameterKey.inputCompactionMode.rawValue: inputCompactionMode,
-            BHPDF417FilterParameterKey.inputCompactStyle.rawValue: inputCompactStyle,
-            BHPDF417FilterParameterKey.inputCorrectionLevel.rawValue: inputCorrectionLevel,
-            BHPDF417FilterParameterKey.inputDataColumns.rawValue: inputDataColumns,
-            BHPDF417FilterParameterKey.inputDataRows.rawValue: inputDataRows,
-            BHPDF417FilterParameterKey.inputMaxHeight.rawValue: inputMaxHeight,
-            BHPDF417FilterParameterKey.inputMaxWidth.rawValue: inputMaxWidth,
-            BHPDF417FilterParameterKey.inputMinHeight.rawValue: inputMinHeight,
-            BHPDF417FilterParameterKey.inputMinWidth.rawValue: inputMinWidth,
-            BHPDF417FilterParameterKey.inputPreferredAspectRatio.rawValue: inputPreferredAspectRatio,
-        ])
+        public func loadInto(_ filter: CIFilter) {
+            filter.setValuesForKeys([
+                BHPDF417FilterParameterKey.inputAlwaysSpecifyCompaction.rawValue: inputAlwaysSpecifyCompaction,
+                BHPDF417FilterParameterKey.inputCompactionMode.rawValue: inputCompactionMode,
+                BHPDF417FilterParameterKey.inputCompactStyle.rawValue: inputCompactStyle,
+                BHPDF417FilterParameterKey.inputCorrectionLevel.rawValue: inputCorrectionLevel,
+                BHPDF417FilterParameterKey.inputDataColumns.rawValue: inputDataColumns,
+                BHPDF417FilterParameterKey.inputDataRows.rawValue: inputDataRows,
+                BHPDF417FilterParameterKey.inputMaxHeight.rawValue: inputMaxHeight,
+                BHPDF417FilterParameterKey.inputMaxWidth.rawValue: inputMaxWidth,
+                BHPDF417FilterParameterKey.inputMinHeight.rawValue: inputMinHeight,
+                BHPDF417FilterParameterKey.inputMinWidth.rawValue: inputMinWidth,
+                BHPDF417FilterParameterKey.inputPreferredAspectRatio.rawValue: inputPreferredAspectRatio,
+            ])
+        }
     }
-}
 
 #endif

--- a/Sources/BarcodeHeroCore/FilterParameters/BHPDF417FilterParameters.swift
+++ b/Sources/BarcodeHeroCore/FilterParameters/BHPDF417FilterParameters.swift
@@ -1,7 +1,8 @@
 // Copyright © 2019 SpotHero, Inc. All rights reserved.
 
-import CoreImage
-import Foundation
+#if canImport(CoreImage)
+    import CoreImage
+    import Foundation
 
 /// https://developer.apple.com/library/content/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html#//apple_ref/doc/filter/ci/CIPDF417BarcodeGenerator
 public struct BHPDF417FilterParameters: BHFilterParameterizable {
@@ -33,3 +34,5 @@ public struct BHPDF417FilterParameters: BHFilterParameterizable {
         ])
     }
 }
+
+#endif

--- a/Sources/BarcodeHeroCore/FilterParameters/BHQRFilterParameters.swift
+++ b/Sources/BarcodeHeroCore/FilterParameters/BHQRFilterParameters.swift
@@ -1,7 +1,8 @@
 // Copyright © 2019 SpotHero, Inc. All rights reserved.
 
-import CoreImage
-import Foundation
+#if canImport(CoreImage)
+    import CoreImage
+    import Foundation
 
 /// https://developer.apple.com/library/content/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html#//apple_ref/doc/filter/ci/CIQRCodeGenerator
 public struct BHQRFilterParameters: BHFilterParameterizable {
@@ -11,3 +12,5 @@ public struct BHQRFilterParameters: BHFilterParameterizable {
         filter.setValue(self.inputCorrectionLevel, forKey: BHQRFilterParameterKey.inputCorrectionLevel.rawValue)
     }
 }
+
+#endif

--- a/Sources/BarcodeHeroCore/FilterParameters/BHQRFilterParameters.swift
+++ b/Sources/BarcodeHeroCore/FilterParameters/BHQRFilterParameters.swift
@@ -1,16 +1,16 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 #if canImport(CoreImage)
     import CoreImage
     import Foundation
 
-/// https://developer.apple.com/library/content/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html#//apple_ref/doc/filter/ci/CIQRCodeGenerator
-public struct BHQRFilterParameters: BHFilterParameterizable {
-    public var inputCorrectionLevel: BHQRInputCorrectionLevel = .medium
+    /// https://developer.apple.com/library/content/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html#//apple_ref/doc/filter/ci/CIQRCodeGenerator
+    public struct BHQRFilterParameters: BHFilterParameterizable {
+        public var inputCorrectionLevel: BHQRInputCorrectionLevel = .medium
 
-    public func loadInto(_ filter: CIFilter) {
-        filter.setValue(self.inputCorrectionLevel, forKey: BHQRFilterParameterKey.inputCorrectionLevel.rawValue)
+        public func loadInto(_ filter: CIFilter) {
+            filter.setValue(self.inputCorrectionLevel, forKey: BHQRFilterParameterKey.inputCorrectionLevel.rawValue)
+        }
     }
-}
 
 #endif

--- a/Sources/BarcodeHeroCore/Generators/BHCode39Generator.swift
+++ b/Sources/BarcodeHeroCore/Generators/BHCode39Generator.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/Sources/BarcodeHeroCore/Generators/BHCode93Generator.swift
+++ b/Sources/BarcodeHeroCore/Generators/BHCode93Generator.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/Sources/BarcodeHeroCore/Generators/BHEANGenerator.swift
+++ b/Sources/BarcodeHeroCore/Generators/BHEANGenerator.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 // public let RSBarcodesTypeISBN13Code = "com.pdq.rsbarcodes.isbn13"
 // public let RSBarcodesTypeISSN13Code = "com.pdq.rsbarcodes.issn13"

--- a/Sources/BarcodeHeroCore/Generators/BHITFGenerator.swift
+++ b/Sources/BarcodeHeroCore/Generators/BHITFGenerator.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/Sources/BarcodeHeroCore/Generators/BHNativeBarcodeGenerator.swift
+++ b/Sources/BarcodeHeroCore/Generators/BHNativeBarcodeGenerator.swift
@@ -1,9 +1,12 @@
 // Copyright © 2019 SpotHero, Inc. All rights reserved.
 
+#if canImport(CoreImage)
 import CoreGraphics
-import CoreImage
-import Foundation
+    import CoreImage
+    import Foundation
 
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
 class BHNativeBarcodeGenerator: BHBarcodeGenerating {
     // MARK: - Properties
 
@@ -85,3 +88,5 @@ class BHNativeBarcodeGenerator: BHBarcodeGenerating {
         //        return UIImage(cgImage: cgImage, scale: 1, orientation: UIImageOrientation.up)
     }
 }
+
+#endif

--- a/Sources/BarcodeHeroCore/Generators/BHNativeBarcodeGenerator.swift
+++ b/Sources/BarcodeHeroCore/Generators/BHNativeBarcodeGenerator.swift
@@ -1,45 +1,45 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 #if canImport(CoreImage)
-import CoreGraphics
+    import CoreGraphics
     import CoreImage
     import Foundation
 
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
-class BHNativeBarcodeGenerator: BHBarcodeGenerating {
-    // MARK: - Properties
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    class BHNativeBarcodeGenerator: BHBarcodeGenerating {
+        // MARK: - Properties
 
-    var acceptedTypes: [BHBarcodeType] = [.aztec, .code128, .pdf417, .qr]
+        var acceptedTypes: [BHBarcodeType] = [.aztec, .code128, .pdf417, .qr]
 
-    // MARK: - Methods
+        // MARK: - Methods
 
-    func generate(_ barcodeType: BHBarcodeType, withData rawData: String, options: BHBarcodeOptions? = nil) throws -> CGImage {
-        try validate(rawData, for: barcodeType)
+        func generate(_ barcodeType: BHBarcodeType, withData rawData: String, options: BHBarcodeOptions? = nil) throws -> CGImage {
+            try validate(rawData, for: barcodeType)
 
-        let data = rawData.data(using: .isoLatin1, allowLossyConversion: false)
+            let data = rawData.data(using: .isoLatin1, allowLossyConversion: false)
 
-        guard let generator = try BHNativeCodeGeneratorType(barcodeType: barcodeType) else {
-            throw BHError.couldNotGetGenerator(barcodeType)
-        }
+            guard let generator = try BHNativeCodeGeneratorType(barcodeType: barcodeType) else {
+                throw BHError.couldNotGetGenerator(barcodeType)
+            }
 
-        let context = CIContext(options: nil)
+            let context = CIContext(options: nil)
 
-        guard let filter = CIFilter(name: generator.rawValue) else {
-            throw BHError.couldNotCreateFilter(barcodeType)
-        }
+            guard let filter = CIFilter(name: generator.rawValue) else {
+                throw BHError.couldNotCreateFilter(barcodeType)
+            }
 
-        filter.setValue(data, forKey: BHFilterParameterKey.inputMessage.rawValue)
+            filter.setValue(data, forKey: BHFilterParameterKey.inputMessage.rawValue)
 
-        if let filterParameters = options?.filterParameters {
-            filterParameters.loadInto(filter)
+            if let filterParameters = options?.filterParameters {
+                filterParameters.loadInto(filter)
 //            for parameter in filterParameters {
 //                filter.setValue(parameter.value, forKey: parameter.key)
 //            }
-        } else if barcodeType == .code128 {
-            // TODO: We are replacing the native quiet zone here, figure out a better way to load defaults
-            BHCode128FilterParameters().loadInto(filter)
-        }
+            } else if barcodeType == .code128 {
+                // TODO: We are replacing the native quiet zone here, figure out a better way to load defaults
+                BHCode128FilterParameters().loadInto(filter)
+            }
 
 //        switch barcodeType {
 //        case .aztec:
@@ -57,39 +57,38 @@ class BHNativeBarcodeGenerator: BHBarcodeGenerating {
 //            throw BHError.nonNativeType(barcodeType)
 //        }
 
-        var filterImage: CIImage?
-        
-        if
-            let fillColor = options?.fillColor,
-            let strokeColor = options?.strokeColor {
-            
+            var filterImage: CIImage?
+
+            if
+                let fillColor = options?.fillColor,
+                let strokeColor = options?.strokeColor {
                 // Create a color filter to pass the image through
                 let colorFilter = CIFilter(name: "CIFalseColor")
                 colorFilter?.setValue(filter.outputImage, forKey: BHColorFilterParameterKey.inputImage.rawValue)
                 colorFilter?.setValue(CIColor(cgColor: fillColor), forKey: BHColorFilterParameterKey.backgroundColor.rawValue)
                 colorFilter?.setValue(CIColor(cgColor: strokeColor), forKey: BHColorFilterParameterKey.foregroundColor.rawValue)
-                
+
                 filterImage = colorFilter?.outputImage
-        } else {
-            filterImage = filter.outputImage
-        }
-        
-        guard
-            let ciImage = filterImage,
-            let cgImage = context.createCGImage(ciImage, from: ciImage.extent) else {
+            } else {
+                filterImage = filter.outputImage
+            }
+
+            guard
+                let ciImage = filterImage,
+                let cgImage = context.createCGImage(ciImage, from: ciImage.extent) else {
                 throw BHError.couldNotCreateImage(barcodeType)
+            }
+
+            return cgImage
+
+            // Keeping the following block around (and commented) just in case
+            //        guard let outputImage = filter.outputImage,
+            //            let cgImage = CIContext(options: nil).createCGImage(outputImage, from: outputImage.extent) else {
+            //                return nil
+            //        }
+            //
+            //        return UIImage(cgImage: cgImage, scale: 1, orientation: UIImageOrientation.up)
         }
-
-        return cgImage
-
-        // Keeping the following block around (and commented) just in case
-        //        guard let outputImage = filter.outputImage,
-        //            let cgImage = CIContext(options: nil).createCGImage(outputImage, from: outputImage.extent) else {
-        //                return nil
-        //        }
-        //
-        //        return UIImage(cgImage: cgImage, scale: 1, orientation: UIImageOrientation.up)
     }
-}
 
 #endif

--- a/Sources/BarcodeHeroCore/Generators/BHUPCEGenerator.swift
+++ b/Sources/BarcodeHeroCore/Generators/BHUPCEGenerator.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/Sources/BarcodeHeroCore/Helpers/BHBarcodeGenerator.swift
+++ b/Sources/BarcodeHeroCore/Helpers/BHBarcodeGenerator.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import AVFoundation
 import CoreGraphics
@@ -20,7 +20,7 @@ public class BHBarcodeGenerator {
 
         return try generator.generate(barcodeType, withData: data, options: options)
     }
-    
+
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     public class func generate(_ metadataObjectType: AVMetadataObject.ObjectType?,
@@ -45,9 +45,9 @@ public class BHBarcodeGenerator {
         switch barcodeType {
         case .aztec, .code128, .pdf417, .qr:
             #if os(tvOS) || os(watchOS)
-            return nil
+                return nil
             #else
-            return BHNativeBarcodeGenerator()
+                return BHNativeBarcodeGenerator()
             #endif
         case .code39, .code39Mod43:
             return BHCode39Generator()

--- a/Sources/BarcodeHeroCore/Helpers/BHBarcodeGenerator.swift
+++ b/Sources/BarcodeHeroCore/Helpers/BHBarcodeGenerator.swift
@@ -20,7 +20,9 @@ public class BHBarcodeGenerator {
 
         return try generator.generate(barcodeType, withData: data, options: options)
     }
-
+    
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
     public class func generate(_ metadataObjectType: AVMetadataObject.ObjectType?,
                                withData data: String?,
                                options: BHBarcodeOptions? = nil) throws -> CGImage {
@@ -29,7 +31,7 @@ public class BHBarcodeGenerator {
         }
 
         guard let barcodeType = BHBarcodeType(metadataObjectType: metadataObjectType) else {
-            throw BHError.invalidMetadataObjectType(metadataObjectType)
+            throw BHError.invalidMetadataObjectType(metadataObjectType.rawValue)
         }
 
         return try self.generate(barcodeType, withData: data, options: options)
@@ -42,7 +44,11 @@ public class BHBarcodeGenerator {
 
         switch barcodeType {
         case .aztec, .code128, .pdf417, .qr:
+            #if os(tvOS) || os(watchOS)
+            return nil
+            #else
             return BHNativeBarcodeGenerator()
+            #endif
         case .code39, .code39Mod43:
             return BHCode39Generator()
         case .ean8, .ean13, .isbn13, .issn13:

--- a/Sources/BarcodeHeroCore/Helpers/BHImageHelper.swift
+++ b/Sources/BarcodeHeroCore/Helpers/BHImageHelper.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import AVFoundation
 import Foundation
@@ -14,21 +14,21 @@ import Foundation
 class BHImageHelper {
     /// The default top spacing of the CIImage generated AVMetadataObjectTypePDF417Code type image
     private static let topSpacing: CGFloat = 0
-    
+
     /// The default top spacing of the CIImage generated AVMetadataObjectTypePDF417Code type image
     private static let bottomSpacing: CGFloat = 0
-    
+
     /// The default height of the CIImage generated AVMetadataObjectTypePDF417Code type image
     private static let height: CGFloat = 28
-    
+
     /// The default line width for a 1D barcode
     private static let lineWidth: CGFloat = 1
-    
+
     // TODO: For now, we're not use Quiet Zone spacing and we're expecting the client to adjust padding on their own
     /// The spacing to provide to the quiet zone all around
     /// For 1D barcodes, this should be 10 times the width of the narrowest bar or 1/8 inch, whichever is greater
     private static let quietZoneSpacing: CGFloat = 0 // Self.lineWidth * 10
-    
+
     static func draw(_ data: String, options: BHBarcodeOptions? = nil) throws -> CGImage? {
         guard !data.isEmpty else {
             throw BHError.dataRequired
@@ -95,7 +95,6 @@ class BHImageHelper {
 #if canImport(UIKit) && !os(watchOS)
 
     extension BHImageHelper {
-        
         static func resize(_ image: CGImage,
                            toSize targetSize: CGSize,
                            forContentMode contentMode: UIView.ContentMode = .scaleAspectFit) throws -> CGImage {
@@ -162,7 +161,7 @@ class BHImageHelper {
             }
 
             context.interpolationQuality = CGInterpolationQuality.none
-            
+
             // this puts the origin of the coordinate system into the top-left for drawing,
             // which makes 2D codes orient properly when drawn
             context.translateBy(x: 0, y: height)

--- a/Sources/BarcodeHeroCore/Helpers/BHImageHelper.swift
+++ b/Sources/BarcodeHeroCore/Helpers/BHImageHelper.swift
@@ -1,8 +1,11 @@
 // Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 import AVFoundation
-import CoreImage
 import Foundation
+
+#if canImport(CoreImage)
+    import CoreImage
+#endif
 
 #if canImport(UIKit)
     import UIKit
@@ -89,9 +92,10 @@ class BHImageHelper {
 
 // MARK: BHImageHelper
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 
     extension BHImageHelper {
+        
         static func resize(_ image: CGImage,
                            toSize targetSize: CGSize,
                            forContentMode contentMode: UIView.ContentMode = .scaleAspectFit) throws -> CGImage {

--- a/Sources/BarcodeHeroCore/Protocols/BHBarcodeGenerating.swift
+++ b/Sources/BarcodeHeroCore/Protocols/BHBarcodeGenerating.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import CoreGraphics
 import Foundation

--- a/Sources/BarcodeHeroCore/Protocols/BHFilterParameterizable.swift
+++ b/Sources/BarcodeHeroCore/Protocols/BHFilterParameterizable.swift
@@ -1,14 +1,13 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 import Foundation
 
 #if canImport(CoreImage)
-import CoreImage
+    import CoreImage
 #endif
 
 public protocol BHFilterParameterizable {
     #if canImport(CoreImage)
-    func loadInto(_ filter: CIFilter)
+        func loadInto(_ filter: CIFilter)
     #endif
 }
-

--- a/Sources/BarcodeHeroCore/Protocols/BHFilterParameterizable.swift
+++ b/Sources/BarcodeHeroCore/Protocols/BHFilterParameterizable.swift
@@ -1,8 +1,14 @@
 // Copyright © 2019 SpotHero, Inc. All rights reserved.
 
-import CoreImage
 import Foundation
 
+#if canImport(CoreImage)
+import CoreImage
+#endif
+
 public protocol BHFilterParameterizable {
+    #if canImport(CoreImage)
     func loadInto(_ filter: CIFilter)
+    #endif
 }
+

--- a/Sources/BarcodeHeroUI/Controllers/BHCameraScanController.swift
+++ b/Sources/BarcodeHeroUI/Controllers/BHCameraScanController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 #if canImport(UIKit)
 

--- a/Sources/BarcodeHeroUI/Extensions/UIView+Mask.swift
+++ b/Sources/BarcodeHeroUI/Extensions/UIView+Mask.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 #if canImport(UIKit)
 

--- a/Sources/BarcodeHeroUI/Views/BHFocusAreaView.swift
+++ b/Sources/BarcodeHeroUI/Views/BHFocusAreaView.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 #if canImport(UIKit)
 
@@ -63,10 +63,10 @@
         }
 
         // MARK: Methods - Lifecycle
-        
+
         init() {
             super.init(frame: .zero)
-            
+
             self.translatesAutoresizingMaskIntoConstraints = false
 
             let stackView = UIStackView()
@@ -94,11 +94,11 @@
                 stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
             ])
         }
-        
+
         required convenience init?(coder: NSCoder) {
             self.init()
         }
-        
+
         // MARK: Methods - Utilities
 
         func clear() {

--- a/Tests/BarcodeHeroCoreTests/BarcodeHeroCoreTests.swift
+++ b/Tests/BarcodeHeroCoreTests/BarcodeHeroCoreTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 @testable import BarcodeHeroCore
 import XCTest


### PR DESCRIPTION
**JIRA URL**
https://spothero.atlassian.net/browse/IOS-1879

**Description**
- Added the `BarcodeHeroCore` scheme, to test only that target without `BarcodeHeroUI`.
- Updated `invalidMetadataObjectType` to use the string value instead of the `AVMetadataObject.ObjectType`, which isn't necessary for how it is currently used (and it can be translated back if need be).
- Added lots of `@available` checks to remove support for various classes from watchOS and tvOS platforms.