### PR TITLE
Fix Barcode Size

### DIFF
--- a/Sources/BarcodeHeroCore/BHBarcodeOptions.swift
+++ b/Sources/BarcodeHeroCore/BHBarcodeOptions.swift
@@ -8,7 +8,7 @@ public struct BHBarcodeOptions {
     
     public let fillColor: CGColor?
     public let strokeColor: CGColor?
-    
+    public var qrCorrectionLevel: BHQRInputCorrectionLevel = .low
     public let filterParameters: BHFilterParameterizable?
     
     // MARK: Initialization
@@ -20,9 +20,11 @@ public struct BHBarcodeOptions {
     ///                                 Defaults to nil.
     public init(fillColor: CGColor? = nil,
                 strokeColor: CGColor? = nil,
+                qrCorrectionLevel: BHQRInputCorrectionLevel = .low,
                 filterParameters: BHFilterParameterizable? = nil) {
         self.fillColor = fillColor ?? CGColor.systemSafeWhite
         self.strokeColor = strokeColor ?? CGColor.systemSafeBlack
+        self.qrCorrectionLevel = qrCorrectionLevel
         self.filterParameters = filterParameters
     }
 }

--- a/Sources/BarcodeHeroCore/Generators/BHNativeBarcodeGenerator.swift
+++ b/Sources/BarcodeHeroCore/Generators/BHNativeBarcodeGenerator.swift
@@ -40,7 +40,12 @@
                 // TODO: We are replacing the native quiet zone here, figure out a better way to load defaults
                 BHCode128FilterParameters().loadInto(filter)
             }
-            
+
+            if barcodeType == .qr {
+                let level = (options?.qrCorrectionLevel ?? .low).rawValue
+                filter.setValue(level, forKey: BHQRFilterParameterKey.inputCorrectionLevel.rawValue)
+            }
+
 //        switch barcodeType {
 //        case .aztec:
 //            //            filter.setValue(0, forKey: BHAztecParameters.inputCompactStyle.rawValue)
@@ -57,8 +62,8 @@
 //            throw BHError.nonNativeType(barcodeType)
 //        }
             
-            var filterImage: CIImage?
-            
+            let filterImage: CIImage?
+
             if
                 let fillColor = options?.fillColor,
                 let strokeColor = options?.strokeColor {


### PR DESCRIPTION
**Issue Link**
N/A

**Description**
Set BHQRInputCorrectionLevel to low by default

Operators reported low read rates for “smaller” QR codes on Amano readers.
This PR sets error-correction to Low (L) so each module (square) renders larger and crisper

Hardware scanners fail when module size is too small.

Previously, QR bitmap width differed on 2x vs 3x screens and EC defaulted to M in places resulting in more modules in the same width giving us tiny cells.

EC = L reduces redundancy so the encoder can pick a lower version